### PR TITLE
Update test-cases for new group name

### DIFF
--- a/src/integrationTest/groovy/com/hierynomus/gradle/license/LicenseIntegrationTest.groovy
+++ b/src/integrationTest/groovy/com/hierynomus/gradle/license/LicenseIntegrationTest.groovy
@@ -40,7 +40,7 @@ class LicenseIntegrationTest extends IntegrationSpec {
         id "java"
     }
     
-    apply plugin: "com.github.hierynomus.license-base"
+    apply plugin: "com.benjaminsproule.license-base"
     
     license {
         ignoreFailures = true

--- a/src/integrationTest/groovy/com/hierynomus/gradle/license/LicenseReportIntegrationTest.groovy
+++ b/src/integrationTest/groovy/com/hierynomus/gradle/license/LicenseReportIntegrationTest.groovy
@@ -17,7 +17,7 @@ plugins {
     id "java"
 }
 
-apply plugin: "com.github.hierynomus.license-report"
+apply plugin: "com.benjaminsproule.license-report"
 
 group = "testGroup"
 version = "1.5"

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/AndroidLicensePluginTest.groovy
@@ -162,7 +162,7 @@ class AndroidLicensePluginTest {
 
     @Test
     public void shouldRunLicenseDuringCheck() {
-        project.apply plugin: 'com.github.hierynomus.license'
+        project.apply plugin: 'com.benjaminsproule.license'
         def task = project.tasks.create('licenseManual', LicenseCheck)
 
         Set<Task> dependsOn = project.tasks['check'].getDependsOn()
@@ -174,7 +174,7 @@ class AndroidLicensePluginTest {
 
     @Test
     public void shouldRunLicenseFromBaseTasks() {
-        project.apply plugin: "com.github.hierynomus.license"
+        project.apply plugin: "com.benjaminsproule.license"
         def manual = project.tasks.create('licenseManualCheck', LicenseCheck)
 
         def manualFormat = project.tasks.create('licenseManualFormat', LicenseFormat)

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesTestKitSpec.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/DownloadLicensesTestKitSpec.groovy
@@ -22,7 +22,7 @@ class DownloadLicensesTestKitSpec extends IntegrationSpec {
     def "Should correctly take project.buildDir into account for generated reports"() {
         given:
         buildFile << """
-apply plugin: 'com.github.hierynomus.license'
+apply plugin: 'com.benjaminsproule.license'
 apply plugin: 'java'
 buildDir = "generated"
 

--- a/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
+++ b/src/test/groovy/nl/javadude/gradle/plugins/license/LicensePluginTest.groovy
@@ -120,7 +120,7 @@ class LicensePluginTest {
     @Test
     public void shouldRunLicenseDuringCheck() {
         project.apply plugin: 'java'
-        project.apply plugin: 'com.github.hierynomus.license'
+        project.apply plugin: 'com.benjaminsproule.license'
         def task = project.tasks.create('licenseManual', License)
 
         Set<Task> dependsOn = project.tasks['check'].getDependsOn()
@@ -133,7 +133,7 @@ class LicensePluginTest {
     @Test
     public void shouldRunLicenseFromBaseTasks() {
         project.apply plugin: 'java'
-        project.apply plugin: 'com.github.hierynomus.license'
+        project.apply plugin: 'com.benjaminsproule.license'
         def task = project.tasks.create('licenseManual', LicenseCheck)
         def formatTask = project.tasks.create('licenseManualFormat', LicenseFormat)
 


### PR DESCRIPTION
This fixes the `UnknownPluginExceptions` thrown in the following tests:

```
AndroidLicensePluginTest > shouldRunLicenseFromBaseTasks
AndroidLicensePluginTest > shouldRunLicenseDuringCheck
LicensePluginTest > shouldRunLicenseFromBaseTasks
LicensePluginTest > shouldRunLicenseDuringCheck
```